### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nayu7u/toy-rails-sample/security/code-scanning/7](https://github.com/nayu7u/toy-rails-sample/security/code-scanning/7)

In general, fix this by explicitly specifying minimal `permissions` for the `GITHUB_TOKEN` either at the workflow root (applying to all jobs without their own block) or individually per job. Here, the `test` job already has its own `permissions` block (including `packages: write` and `pull-requests: write`), and we don’t want to alter its behavior. The issue is with jobs like `scan_ruby`, `scan_js`, and `lint`, which currently inherit potentially broader repo defaults. The best fix is to add a workflow-level `permissions` block with read-only access (`contents: read`), placed at the top level (e.g., right after the `name:` or `on:` section). This will apply to all jobs except those that override permissions (like `test`), and it matches the usage of the three scan/lint jobs that only read source code.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Add a top-level `permissions:` section (two-space indentation under the root) specifying at least `contents: read`. No extra imports or dependencies are needed; it’s pure YAML configuration.
- Leave the existing `permissions` block inside the `test` job unchanged so its write permissions remain intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
